### PR TITLE
Set default workflow token permissions to read-only

### DIFF
--- a/.github/workflows/images-to-aws-s3.yml
+++ b/.github/workflows/images-to-aws-s3.yml
@@ -7,6 +7,9 @@ on:
       - images-to-aws-s3/**
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/static-uri.yml
+++ b/.github/workflows/static-uri.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/telemetry-to-aws-iot-core.yml
+++ b/.github/workflows/telemetry-to-aws-iot-core.yml
@@ -7,6 +7,9 @@ on:
       - telemetry-to-aws-iot-core/**
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Token-Permissions** remedy.

It sets the default workflow token to read-only by adding a top-level `permissions` block to workflows that lacked one:

- `.github/workflows/images-to-aws-s3.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/static-uri.yml`
- `.github/workflows/telemetry-to-aws-iot-core.yml`

Any job that needs more than read access must be granted those permissions at the job level, otherwise it may fail.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#token-permissions) for details.