### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/images-to-aws-s3.yml
+++ b/.github/workflows/images-to-aws-s3.yml
@@ -14,5 +14,5 @@ jobs:
       run:
         working-directory: images-to-aws-s3
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - run: sam build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
-      - uses: github/super-linter/slim@v5
+      - uses: github/super-linter/slim@45fc0d88288beee4701c62761281edfee85655d7 # v5.0.0
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/telemetry-to-aws-iot-core.yml
+++ b/.github/workflows/telemetry-to-aws-iot-core.yml
@@ -14,6 +14,6 @@ jobs:
       run:
         working-directory: telemetry-to-aws-iot-core
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - run: pip install --upgrade pip cfn-lint
       - run: cfn-lint template.yaml


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Pinned-Dependencies** remedy.

It pins the GitHub Actions used in the following workflows to full commit SHAs, keeping the original version as a trailing comment:

- `.github/workflows/images-to-aws-s3.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/telemetry-to-aws-iot-core.yml`

Renovate recognises the `@<sha> # <version>` format and will keep these pinned actions updated automatically.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#pinned-dependencies) for details.